### PR TITLE
Document utilities and add script hygiene

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,11 @@
 This repository holds scripts for things best described as
 'Not a good fit to be done in c++ / openhd core'
 An example is configuring the OS for a specific camera on RPI
-(This requires modifying OS-related things like the /boot/config.txt file and a reboot) 
+(This requires modifying OS-related things like the /boot/config.txt file and a reboot)
 
 This repo is packaged into openhd-sys-utils and can be installed from our repository
+
+## Documentation
+
+See [SCRIPTS.md](SCRIPTS.md) for a brief description of each utility script, packaging helper, and supporting asset included in this repository.
 

--- a/SCRIPTS.md
+++ b/SCRIPTS.md
@@ -1,0 +1,35 @@
+# Script Overview
+
+This repository contains helper scripts used by OpenHD system images. Use this document to quickly identify what each script does and where it is expected to run.
+
+## Top-level utilities
+
+- `custom_unmanaged_camera.sh`: Optional hook for custom camera integrations. When `/boot/openhd/unmanaged.txt` exists, it can stand up network connections and stream pipelines for IP or thermal cameras into OpenHD via UDP ports 5500/5501. User-defined streaming functions are provided but commented out by default.
+- `desktop-truster.sh`: Marks all `.desktop` launchers on the current user's desktop as trusted using `gio`, reducing prompts when launching shortcuts.
+- `h264_decode.sh` / `h265_decode.sh`: Sample decode pipelines for receiving OpenHD video over RTP on port 5600 and playing back via GStreamer. The scripts select pipeline variants based on connected hardware (e.g., Rockchip boards) and include helpers for direct framebuffer output.
+- `initPi.sh`: Performs Raspberry Pi specific boot-time setup. Detects kernel version/board, installs overlays, and toggles additional modules and services according to available hardware markers.
+- `initRock.sh`: Adds Rockchip platform identification files and ensures the OpenHD systemd services are enabled when Rockchip markers are present.
+- `initX20.sh`: Initializes the Walksnail Avatar / Caddx Vista (X20) air unit by writing platform markers and enabling temperature monitoring services.
+- `initX86.sh`: Applies x86-specific tweaks, including handling Steam Deck display rotation and enabling the main `openhd_sys_utils` service.
+- `led.sh` / `led_sys.sh`: Simple LED control helpers that write colored status combinations to `/usr/local/share/openhd/led`. The `_sys` variant reads its inputs from files created by the main system services.
+- `mjpeg_decode.sh`: A misnamed but functional H265 decode helper mirroring the pipelines in the other decode scripts for Rockchip hardware.
+- `ohd_camera_setup.sh`: Detects the current platform and writes appropriate boot configuration (e.g., enabling CSI cameras on Raspberry Pi, Rockchip camera setup, or assigning fallback values) based on `uname`/`lsb_release` data.
+- `openhd_emmc_util.sh`: Utility for clearing or burning images to embedded MMC storage. Supports commands such as `clear` and `burn`, optionally rebooting after completion.
+- `openhd_resize_util.sh`: Resizes the configured filesystem when a `resize.txt` sentinel file is present under `/boot/openhd`. Uses `fdisk`, `partprobe`, and `resize2fs` to grow the partition before rebooting.
+- `openhd_sys_utils.sh`: Primary orchestration script executed at boot. Handles debug mode, triggers platform-specific init scripts, optionally clears or resizes storage, and runs camera setup helpers. It also responds to special marker files to perform maintenance tasks.
+- `openhd_update_utils.sh`: Installs `.deb` packages placed in `/boot/openhd/update`. Processes optional `update.zip`, logs results to `/boot/openhd/install-log.txt`, and reboots on success.
+- `status.sh`: Aggregates status files under `/tmp/openhd_status` into a single `status.txt`, checking for warning/error markers to set the exit code.
+- `steamdeck.sh`: Convenience script to rotate the display on Steam Deck hardware when the touchscreen device is detected.
+- `x86-core.sh`: Core service entrypoint for generic x86 images. Handles first-boot filesystem resize, optional Steam Deck rotation, enabling VNC, and configuring wireless access points.
+
+## Packaging scripts
+
+- `packaging/before-install.sh`: Cleans up MOTD and leftover `x20` header artifacts before packaging installs.
+- `packaging/after-install.sh`: Restores the MOTD, configures Raspberry Pi autologin when applicable, and prunes X20-specific files on non-custom installations.
+
+## Other resources
+
+- `audio/audio_playback_rpi.service`: Systemd unit to launch Raspberry Pi audio playback for OpenHD.
+- `misc/`: Collection of configuration assets (boot configuration templates, MOTD, wallpaper, and user prompts) used during packaging or platform setup.
+- `shortcuts/`: Desktop launchers and icons for OpenHD utilities and companion applications.
+- `x20/`: Platform-specific resources for the X20 hardware family, including temperature guardian service assets and binary blobs.

--- a/mjpeg_decode.sh
+++ b/mjpeg_decode.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-#Simple decode script for OpenHD (h265)
+# Simple decode script for OpenHD (H265)
 
 function execute_kmsDecodeMPP {
     local plane=$1

--- a/openhd_resize_util.sh
+++ b/openhd_resize_util.sh
@@ -1,4 +1,6 @@
-#resize function
+#!/bin/bash
+
+# resize function
 
 # Specify the UUID of the partition you want to resize
 PARTITION_UUID=$1

--- a/packaging/after-install.sh
+++ b/packaging/after-install.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 cp /usr/local/share/openhd_misc/motd /etc/motd
 cat /etc/motd
 

--- a/packaging/before-install.sh
+++ b/packaging/before-install.sh
@@ -1,2 +1,4 @@
+#!/bin/bash
+
 rm -Rf /etc/motd
 rm -Rf /usr/local/bin/x20_header.h264


### PR DESCRIPTION
## Summary
- add a SCRIPTS.md reference outlining the purpose of each utility and resource
- link documentation from the README and clean up decode script naming
- add shebangs and tidy packaging and resize helper scripts

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f7ba020e4832fb0dd0e8d5b687540)