### PR TITLE
Add OpenHD system orchestrator binary and CMake build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,11 @@
+cmake_minimum_required(VERSION 3.10)
+project(openhd_sys_utils LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+add_executable(openhd_sys_utils
+    src/openhd_sys_utils.cpp
+)
+
+target_include_directories(openhd_sys_utils PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src)

--- a/README.md
+++ b/README.md
@@ -9,3 +9,15 @@ This repo is packaged into openhd-sys-utils and can be installed from our reposi
 
 See [SCRIPTS.md](SCRIPTS.md) for a brief description of each utility script, packaging helper, and supporting asset included in this repository.
 
+## Building `openhd_sys_utils`
+
+The `openhd_sys_utils` orchestrator is built with CMake and depends only on the standard C++17 library. To compile the binary:
+
+```bash
+mkdir -p build
+cd build
+cmake ..
+cmake --build .
+```
+
+The resulting executable is placed at `build/openhd_sys_utils`. Install it to `/usr/local/bin/openhd_sys_utils` (or another location in `PATH`) so `openhd_sys_utils.service` can launch it.

--- a/openhd_sys_utils.service
+++ b/openhd_sys_utils.service
@@ -1,9 +1,9 @@
 [Unit]
-Description=Install updates on boot
+Description=OpenHD system utilities orchestrator
 
 [Service]
 Type=simple
-ExecStart=/bin/bash /usr/local/bin/openhd_sys_utils.sh
+ExecStart=/usr/local/bin/openhd_sys_utils
 
 [Install]
 WantedBy=multi-user.target

--- a/src/openhd_sys_utils.cpp
+++ b/src/openhd_sys_utils.cpp
@@ -1,0 +1,273 @@
+#include <cstdlib>
+#include <cerrno>
+#include <cstring>
+#include <filesystem>
+#include <iostream>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <poll.h>
+#include <sys/socket.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <sys/un.h>
+#include <sys/wait.h>
+#include <unordered_map>
+#include <unistd.h>
+#include <vector>
+#include <fcntl.h>
+
+namespace {
+constexpr std::string_view kSocketDir = "/run/openhd";
+constexpr std::string_view kSocketPath = "/run/openhd/openhd_sys.sock";
+constexpr std::size_t kMaxLineLength = 4096;
+
+bool setNonBlocking(int fd) {
+    const int flags = fcntl(fd, F_GETFL, 0);
+    if (flags == -1) return false;
+    return fcntl(fd, F_SETFL, flags | O_NONBLOCK) != -1;
+}
+
+std::optional<std::string> extractStringField(const std::string& line, const std::string& key) {
+    const std::string needle = "\"" + key + "\"";
+    auto keyPos = line.find(needle);
+    if (keyPos == std::string::npos) return std::nullopt;
+
+    auto colonPos = line.find(':', keyPos + needle.size());
+    if (colonPos == std::string::npos) return std::nullopt;
+
+    auto quoteStart = line.find('"', colonPos + 1);
+    if (quoteStart == std::string::npos) return std::nullopt;
+
+    auto quoteEnd = line.find('"', quoteStart + 1);
+    if (quoteEnd == std::string::npos || quoteEnd <= quoteStart + 1) return std::nullopt;
+
+    return line.substr(quoteStart + 1, quoteEnd - quoteStart - 1);
+}
+
+std::optional<int> extractIntField(const std::string& line, const std::string& key) {
+    const std::string needle = "\"" + key + "\"";
+    auto keyPos = line.find(needle);
+    if (keyPos == std::string::npos) return std::nullopt;
+
+    auto colonPos = line.find(':', keyPos + needle.size());
+    if (colonPos == std::string::npos) return std::nullopt;
+
+    colonPos = line.find_first_not_of(" \t", colonPos + 1);
+    if (colonPos == std::string::npos) return std::nullopt;
+
+    char* endPtr = nullptr;
+    const char* start = line.c_str() + colonPos;
+    long value = std::strtol(start, &endPtr, 10);
+    if (start == endPtr) return std::nullopt;
+    return static_cast<int>(value);
+}
+
+void processLine(const std::string& line) {
+    if (line.empty()) return;
+
+    auto state = extractStringField(line, "state");
+    auto severity = extractIntField(line, "severity");
+    if (state || severity) {
+        std::cout << "OpenHD state: " << (state ? *state : "UNKNOWN")
+                  << " (severity=" << (severity ? std::to_string(*severity) : "?") << ")"
+                  << std::endl;
+    } else {
+        std::cout << "OpenHD message: " << line << std::endl;
+    }
+}
+
+int createAndBindSocket() {
+    std::error_code ec;
+    std::filesystem::create_directories(kSocketDir, ec);
+    if (ec) {
+        std::cerr << "Failed to create socket directory " << kSocketDir << ": " << ec.message() << std::endl;
+        return -1;
+    }
+
+    ::unlink(std::string(kSocketPath).c_str());
+
+    int serverFd = ::socket(AF_UNIX, SOCK_STREAM, 0);
+    if (serverFd < 0) {
+        std::perror("socket");
+        return -1;
+    }
+
+    sockaddr_un addr{};
+    addr.sun_family = AF_UNIX;
+    if (kSocketPath.size() >= sizeof(addr.sun_path)) {
+        std::cerr << "Socket path is too long: " << kSocketPath << std::endl;
+        ::close(serverFd);
+        return -1;
+    }
+    std::strncpy(addr.sun_path, std::string(kSocketPath).c_str(), sizeof(addr.sun_path) - 1);
+
+    mode_t oldMask = ::umask(0);
+    if (::bind(serverFd, reinterpret_cast<sockaddr*>(&addr), sizeof(addr)) < 0) {
+        std::perror("bind");
+        ::close(serverFd);
+        ::umask(oldMask);
+        return -1;
+    }
+    ::umask(oldMask);
+
+    if (::chmod(std::string(kSocketPath).c_str(), 0660) < 0) {
+        std::perror("chmod");
+        ::close(serverFd);
+        return -1;
+    }
+
+    if (::listen(serverFd, 8) < 0) {
+        std::perror("listen");
+        ::close(serverFd);
+        return -1;
+    }
+
+    if (!setNonBlocking(serverFd)) {
+        std::perror("fcntl");
+    }
+
+    return serverFd;
+}
+
+pid_t launchOpenHD() {
+    pid_t pid = ::fork();
+    if (pid < 0) {
+        std::perror("fork");
+        return -1;
+    }
+
+    if (pid == 0) {
+        const char* argv[] = {"openhd", "-a", nullptr};
+        ::execvp(argv[0], const_cast<char* const*>(argv));
+        std::perror("execvp");
+        _exit(127);
+    }
+
+    std::cout << "Launched OpenHD with PID " << pid << std::endl;
+    return pid;
+}
+
+void closeClient(int fd, std::unordered_map<int, std::string>& buffers) {
+    ::close(fd);
+    buffers.erase(fd);
+}
+
+bool handleClientData(int fd, std::unordered_map<int, std::string>& buffers) {
+    char readBuf[1024];
+    while (true) {
+        ssize_t count = ::read(fd, readBuf, sizeof(readBuf));
+        if (count > 0) {
+            auto& buffer = buffers[fd];
+            buffer.append(readBuf, static_cast<std::size_t>(count));
+            if (buffer.size() > kMaxLineLength * 2) {
+                buffer.erase(0, buffer.size() - kMaxLineLength);
+            }
+            std::size_t pos = 0;
+            while ((pos = buffer.find('\n')) != std::string::npos) {
+                std::string line = buffer.substr(0, pos);
+                buffer.erase(0, pos + 1);
+                if (line.size() > kMaxLineLength) {
+                    line = line.substr(0, kMaxLineLength);
+                }
+                processLine(line);
+            }
+        } else if (count == 0) {
+            return false;
+        } else {
+            if (errno == EAGAIN || errno == EWOULDBLOCK) {
+                break;
+            }
+            return false;
+        }
+    }
+    return true;
+}
+}  // namespace
+
+int main() {
+    if (::geteuid() != 0) {
+        std::cerr << "openhd_sys_utils must be run as root." << std::endl;
+        return 1;
+    }
+
+    int serverFd = createAndBindSocket();
+    if (serverFd < 0) {
+        return 1;
+    }
+
+    pid_t childPid = launchOpenHD();
+    if (childPid < 0) {
+        ::close(serverFd);
+        return 1;
+    }
+
+    std::unordered_map<int, std::string> clientBuffers;
+    std::vector<pollfd> pollFds;
+    bool running = true;
+    int exitCode = 0;
+
+    while (running) {
+        int status = 0;
+        pid_t res = ::waitpid(childPid, &status, WNOHANG);
+        if (res == childPid) {
+            if (WIFEXITED(status)) {
+                exitCode = WEXITSTATUS(status);
+                std::cout << "OpenHD exited with code " << exitCode << std::endl;
+            } else if (WIFSIGNALED(status)) {
+                exitCode = 128 + WTERMSIG(status);
+                std::cout << "OpenHD terminated by signal " << WTERMSIG(status) << std::endl;
+            }
+            running = false;
+        }
+        if (!running) {
+            break;
+        }
+
+        pollFds.clear();
+        pollFds.push_back({serverFd, POLLIN, 0});
+        for (const auto& entry : clientBuffers) {
+            pollFds.push_back({entry.first, POLLIN | POLLERR | POLLHUP, 0});
+        }
+
+        int ready = ::poll(pollFds.data(), pollFds.size(), 500);
+        if (ready < 0) {
+            if (errno == EINTR) {
+                continue;
+            }
+            std::perror("poll");
+            break;
+        }
+
+        for (const auto& pfd : pollFds) {
+            if (pfd.revents == 0) continue;
+            if (pfd.fd == serverFd && (pfd.revents & POLLIN)) {
+                while (true) {
+                    int clientFd = ::accept(serverFd, nullptr, nullptr);
+                    if (clientFd < 0) {
+                        if (errno == EAGAIN || errno == EWOULDBLOCK) break;
+                        std::perror("accept");
+                        break;
+                    }
+                    setNonBlocking(clientFd);
+                    clientBuffers.emplace(clientFd, std::string{});
+                }
+            } else if (pfd.fd != serverFd) {
+                if (pfd.revents & (POLLERR | POLLHUP)) {
+                    closeClient(pfd.fd, clientBuffers);
+                } else if (pfd.revents & POLLIN) {
+                    if (!handleClientData(pfd.fd, clientBuffers)) {
+                        closeClient(pfd.fd, clientBuffers);
+                    }
+                }
+            }
+        }
+    }
+
+    for (auto& entry : clientBuffers) {
+        ::close(entry.first);
+    }
+    ::close(serverFd);
+    ::unlink(std::string(kSocketPath).c_str());
+    return exitCode;
+}


### PR DESCRIPTION
### Motivation
- Provide a small orchestrator that runs as root, hosts a Unix domain socket, and launches OpenHD to centralize state updates.
- Ensure OpenHD status messages are exposed via a stable socket path so other components can consume them.
- Improve robustness by using non-blocking IO and monitoring the OpenHD child process to avoid hangs or silent failures.

### Description
- Add `src/openhd_sys_utils.cpp` which enforces `geteuid() == 0`, creates `/run/openhd/openhd_sys.sock`, accepts connections, reads newline-delimited JSON, extracts `state` and `severity`, and prints friendly status lines.
- Launch `openhd -a` using `fork()` + `execvp()` and monitor the child with `waitpid()` to detect exit or signals and return the same code.
- Implement non-blocking sockets, a simple line buffer with a 4KB guard, tolerant parsing for malformed input, and cleanup of stale socket files on startup/exit.
- Add `CMakeLists.txt`, update `openhd_sys_utils.service` to run the new executable, and document build instructions in `README.md`.

### Testing
- Configured the project with `cmake ..` in a `build` directory and the configuration step completed successfully.
- Built the project with `cmake --build .` and the `openhd_sys_utils` executable was compiled and linked successfully.
- No automated runtime tests were added; manual execution and integration testing are expected when running as root with OpenHD available.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695c6744e940832fa6522efa7f158a3a)