### PR TITLE
Stop launching OpenHD and always show status in openhd_sys_utils

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,14 +24,9 @@ The resulting executable is placed at `build/openhd_sys_utils`. Install it to `/
 
 ### Runtime usage
 
-Run as root:
+Run as root to listen for status updates emitted via `/run/openhd/openhd_sys.sock`:
 
 ```bash
 sudo /usr/local/bin/openhd_sys_utils
 ```
-
-Pass `-hidden` to suppress status output and keep OpenHD running quietly in the background:
-
-```bash
-sudo /usr/local/bin/openhd_sys_utils -hidden
-```
+The utility no longer launches OpenHD itself; start OpenHD separately and use this tool to surface status messages.


### PR DESCRIPTION
### Motivation

- Simplify `openhd_sys_utils` so it only surfaces status messages instead of managing the OpenHD process lifecycle.
- Remove the `-hidden` behavior so status output is always printed for easier visibility.
- Reduce coupling and responsibility of the utility (no implicit process launching or child monitoring).

### Description

- Remove `launchOpenHD` and all `waitpid`/child-monitoring logic so the binary no longer forks or starts `openhd`.
- Remove the `-hidden` CLI handling and change `processLine`/`handleClientData` signatures to always print incoming messages.
- Drop unused `#include <sys/wait.h>` and add minor cleanup for unused `argc`/`argv` variables in `main`.
- Update `README.md` runtime guidance to state that `openhd_sys_utils` listens on `/run/openhd/openhd_sys.sock` and no longer launches OpenHD.

### Testing

- Ran `cmake -S . -B build` which configured the project successfully.
- Ran `cmake --build build` which completed and produced the `openhd_sys_utils` binary.
- Verified the project builds cleanly after the changes with no compiler errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695c6a1997c0832f86fbaccfe8865eab)