### PR TITLE
added `X_PLATFORM_TYPE_RPI_5` detection

### DIFF
--- a/misc/platforms.json
+++ b/misc/platforms.json
@@ -70,6 +70,22 @@
       ]
     },
     {
+      "platform": "X_PLATFORM_TYPE_RPI_5",
+      "log": "Raspberry Pi 5 detected (Raspberry Pi OS).",
+      "conditions": [
+        {"type": "file_exists", "path": "/boot/config.txt"},
+        {"type": "file_contains_any", "path": "/proc/cpuinfo", "values": ["Raspberry Pi 5 Model B"]}
+      ]
+    },
+    {
+      "platform": "X_PLATFORM_TYPE_RPI_5",
+      "log": "Raspberry Pi 5 detected (Ubuntu OS).",
+      "conditions": [
+        {"type": "file_exists", "path": "/boot/firmware/config.txt"},
+        {"type": "file_contains_any", "path": "/proc/cpuinfo", "values": ["Raspberry Pi 5 Model B"]}
+      ]
+    },
+    {
       "platform": "X_PLATFORM_TYPE_OPENIPC_SIGMASTAR_UNDEFINED",
       "log": "Detected SigmaStar platform.",
       "conditions": [


### PR DESCRIPTION
Modified platforms.json by adding RPI5 detection (tested on Ubuntu)

TO Research: X_PLATFORM_TYPE_RPI_CM4 and X_PLATFORM_TYPE_RPI_5 have the same ID, potentially issue???