### PR TITLE
[codex] Configure quiet RK3566 Bookworm boot

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -114,6 +114,11 @@ install(TARGETS openhd_sys_utils
 )
 
 install(
+    PROGRAMS ${CMAKE_CURRENT_SOURCE_DIR}/sbin/openhd-rk3566-bookworm-splash-setup
+    DESTINATION /usr/local/sbin
+)
+
+install(
     FILES ${CMAKE_CURRENT_SOURCE_DIR}/systemd/openhd-sys-utils.service
     DESTINATION /lib/systemd/system
 )
@@ -127,6 +132,9 @@ set(CPACK_PACKAGE_VERSION ${PROJECT_VERSION})
 set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "OpenHD system utilities")
 set(CPACK_DEBIAN_PACKAGE_SECTION "utils")
 set(CPACK_DEBIAN_FILE_NAME DEB-DEFAULT)
+set(CPACK_DEBIAN_PACKAGE_CONTROL_EXTRA
+    "${CMAKE_CURRENT_SOURCE_DIR}/packaging/postinst"
+)
 set(CPACK_PROJECT_CONFIG_FILE ${CMAKE_CURRENT_BINARY_DIR}/cpack_project_config.cmake)
 configure_file(
     ${CMAKE_CURRENT_SOURCE_DIR}/cmake/cpack_project_config.cmake.in

--- a/packaging/postinst
+++ b/packaging/postinst
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+set -e
+
+case "$1" in
+    configure|triggered)
+        if [ -x /usr/local/sbin/openhd-rk3566-bookworm-splash-setup ]; then
+            /usr/local/sbin/openhd-rk3566-bookworm-splash-setup || true
+        fi
+        ;;
+esac
+
+exit 0

--- a/sbin/openhd-rk3566-bookworm-splash-setup
+++ b/sbin/openhd-rk3566-bookworm-splash-setup
@@ -1,0 +1,89 @@
+#!/bin/sh
+
+set -e
+
+is_bookworm()
+{
+    grep -qs 'VERSION_CODENAME=bookworm' /etc/os-release ||
+        grep -qs 'VERSION_ID="12"' /etc/os-release ||
+        grep -qs 'VERSION_ID=12' /etc/os-release
+}
+
+is_rk3566()
+{
+    if [ -r /proc/device-tree/compatible ] &&
+        tr '\000' '\n' < /proc/device-tree/compatible 2>/dev/null |
+            grep -q '^rockchip,rk3566$'; then
+        return 0
+    fi
+
+    if [ -f /config/openhd/rock-rk3566.txt ] ||
+        [ -f /boot/openhd/rock-rk3566.txt ] ||
+        [ -f /boot/openhd/openhd/rock-rk3566.txt ]; then
+        return 0
+    fi
+
+    if command -v dpkg-query >/dev/null 2>&1 &&
+        dpkg-query -W -f='${Status}' u-boot-radxa-zero3 2>/dev/null |
+            grep -q 'install ok installed'; then
+        return 0
+    fi
+
+    return 1
+}
+
+set_u_boot_value()
+{
+    key="$1"
+    value="$2"
+    file=/etc/default/u-boot
+
+    [ -f "$file" ] || return 0
+
+    tmp="${file}.openhd-tmp"
+    if grep -Eq "^[#[:space:]]*${key}=" "$file"; then
+        sed -E "s|^[#[:space:]]*${key}=.*|${key}=\"${value}\"|" "$file" > "$tmp"
+    else
+        cp "$file" "$tmp"
+        printf '%s="%s"\n' "$key" "$value" >> "$tmp"
+    fi
+    cat "$tmp" > "$file"
+    rm -f "$tmp"
+}
+
+normalize_kernel_cmdline()
+{
+    file=/etc/kernel/cmdline
+    [ -f "$file" ] || return 0
+
+    old="$(cat "$file")"
+    new=""
+
+    for token in $old; do
+        case "$token" in
+            console=tty1|quiet|splash|loglevel=*|systemd.show_status=*|rd.systemd.show_status=*|vt.global_cursor_default=*)
+                ;;
+            *)
+                new="${new:+$new }$token"
+                ;;
+        esac
+    done
+
+    new="${new:+$new }quiet splash loglevel=0 systemd.show_status=false rd.systemd.show_status=false vt.global_cursor_default=0"
+
+    if [ "$new" != "$old" ]; then
+        cp "$file" "${file}.openhd.bak"
+        printf '%s\n' "$new" > "$file"
+    fi
+}
+
+is_bookworm || exit 0
+is_rk3566 || exit 0
+
+set_u_boot_value U_BOOT_PROMPT 0
+set_u_boot_value U_BOOT_TIMEOUT 0
+normalize_kernel_cmdline
+
+if command -v u-boot-update >/dev/null 2>&1; then
+    u-boot-update || true
+fi


### PR DESCRIPTION
## Summary

Configure RK3566 Bookworm boards for a quiet HDMI boot until OpenHD Glide takes over.

This adds a packaged helper that:
- only runs on Debian Bookworm RK3566 targets
- detects RK3566 on a live board through `/proc/device-tree/compatible`
- detects RK3566 in an image/chroot through existing OpenHD RK3566 marker files or the `u-boot-radxa-zero3` package
- disables the U-Boot prompt/timeout through `/etc/default/u-boot`
- removes `console=tty1` from `/etc/kernel/cmdline`
- enforces `quiet splash loglevel=0 systemd.show_status=false rd.systemd.show_status=false vt.global_cursor_default=0`
- runs `u-boot-update` so `/boot/extlinux/extlinux.conf` is regenerated

The Debian `postinst` calls the helper by absolute path, so installing the `.deb` applies the configuration automatically both on-device and in a suitable RK3566 image chroot.

## Validation

- Tested the helper on a live RK3566 Bookworm board at `192.168.1.52`.
- Rebooted the board and verified SSH returned.
- Verified `openhd-sys-utils.service` and `openhd-glide.service` were active.
- User confirmed the boot is now quiet until Glide starts.
- Verified the updated helper still runs successfully after adding chroot-safe detection.